### PR TITLE
Use InetAddress to determine host name instead of defaulting to localhost

### DIFF
--- a/src/main/java/com/federecio/dropwizard/swagger/SwaggerDropwizard.java
+++ b/src/main/java/com/federecio/dropwizard/swagger/SwaggerDropwizard.java
@@ -15,8 +15,6 @@
  */
 package com.federecio.dropwizard.swagger;
 
-import java.io.IOException;
-
 import io.dropwizard.Configuration;
 import io.dropwizard.server.ServerFactory;
 import io.dropwizard.server.SimpleServerFactory;
@@ -24,10 +22,13 @@ import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import io.dropwizard.views.ViewBundle;
 
+import java.io.IOException;
+
 /**
  * @author Federico Recio
  */
 public class SwaggerDropwizard {
+
 
     public void onInitialize(Bootstrap<?> bootstrap) {
         bootstrap.addBundle(new SwaggerBundle());


### PR DESCRIPTION
When deploying a dropwizard service to a remote host which doesn't have /var/lib/cloud directory, the hostname defaults to localhost. So all the api queries get made to localhost instead of the actual host name. 

Example if I have a dropwizard service called blah-001.yammer.com and I deploy this with the swagger bundle and hit blah-001.yammer.com:8080/swagger and use one of the api's say /getName the call gets made to localhost:8080/getName instead of blah-001.yammer.com:8080/getName

Using InetAddress to get the host fixes this issue
