### PR TITLE
Exclusion in POM dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ How to use it
                 <exclusion>
                     <groupId>io.dropwizard</groupId>
                     <artifactId>*</artifactId>
-		</exclusion>
+                </exclusion>
             </exclusions>
         </dependency>
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ How to use it
             <groupId>io.federecio</groupId>
             <artifactId>dropwizard-swagger</artifactId>
             <version>0.5</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.dropwizard</groupId>
+                    <artifactId>*</artifactId>
+		</exclusion>
+            </exclusions>
         </dependency>
 
 


### PR DESCRIPTION
IMO it'd be wise to instruct users to exclude any `io.dropwizard` dependencies from the io.federecio:dropwizard-swagger dependency because they have an explicit non-transitive Dropwizard dependency anyway. That way one can avoid clashes between different versions.
