### PR TITLE
Exclude libraries from swagger-jaxrs for shade overlay warnings.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,8 +114,20 @@
                     <artifactId>jackson-core</artifactId>
                 </exclusion>
                 <exclusion>
+                    <groupId>com.google.code.findbugs</groupId>
+                    <artifactId>annotations</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>commons-lang</groupId>
                     <artifactId>commons-lang</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javassist</groupId>
+                    <artifactId>javassist</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.ws.rs</groupId>
+                    <artifactId>jsr311-api</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>joda-time</groupId>


### PR DESCRIPTION
Without these exclusions one must manually exclude these jars from dropwizard-swagger if they want to resolve shade overlay warnings.
