### PR TITLE
switching to dropwizard 0.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ dropwizard-swagger
 
 a Dropwizard bundle that serves Swagger UI static content and loads Swagger endpoints. Swagger UI static content is taken from https://github.com/wordnik/swagger-ui
 
-Current version has been tested with Dropwizard 0.7.1 and Swagger 1.3.12
+Current version has been tested with Dropwizard 0.8.0 and Swagger 1.3.12
 
 __NOTE__: the project's group id has been changed `io.federecio` and therefore all packages have been renamed accordingly
 

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     </scm>
 
     <properties>
-        <dropwizard.version>0.7.1</dropwizard.version>
+        <dropwizard.version>0.8.0</dropwizard.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <file.encoding>UTF-8</file.encoding>
@@ -137,6 +137,10 @@
                     <groupId>com.google.code.findbugs</groupId>
                     <artifactId>jsr305</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.javassist</groupId>
+                    <artifactId>javassist</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -188,7 +192,7 @@
         <dependency>
             <groupId>io.federecio</groupId>
             <artifactId>dropwizard-junit</artifactId>
-            <version>0.5</version>
+            <version>0.6-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/io/federecio/dropwizard/swagger/SwaggerBundle.java
+++ b/src/main/java/io/federecio/dropwizard/swagger/SwaggerBundle.java
@@ -20,7 +20,7 @@ import io.dropwizard.setup.Environment;
 
 import java.io.IOException;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * @author Tristan Burch

--- a/src/main/java/io/federecio/dropwizard/swagger/SwaggerDropwizard.java
+++ b/src/main/java/io/federecio/dropwizard/swagger/SwaggerDropwizard.java
@@ -15,13 +15,6 @@
  */
 package io.federecio.dropwizard.swagger;
 
-import com.wordnik.swagger.config.ScannerFactory;
-import com.wordnik.swagger.jaxrs.config.DefaultJaxrsScanner;
-import com.wordnik.swagger.jaxrs.listing.ApiDeclarationProvider;
-import com.wordnik.swagger.jaxrs.listing.ApiListingResourceJSON;
-import com.wordnik.swagger.jaxrs.listing.ResourceListingProvider;
-import com.wordnik.swagger.jaxrs.reader.DefaultJaxrsApiReader;
-import com.wordnik.swagger.reader.ClassReaders;
 import io.dropwizard.Configuration;
 import io.dropwizard.ConfiguredBundle;
 import io.dropwizard.assets.AssetsBundle;
@@ -30,6 +23,15 @@ import io.dropwizard.setup.Environment;
 import io.dropwizard.views.ViewBundle;
 
 import java.io.IOException;
+
+import com.google.common.collect.ImmutableMap;
+import com.wordnik.swagger.config.ScannerFactory;
+import com.wordnik.swagger.jaxrs.config.DefaultJaxrsScanner;
+import com.wordnik.swagger.jaxrs.listing.ApiDeclarationProvider;
+import com.wordnik.swagger.jaxrs.listing.ApiListingResourceJSON;
+import com.wordnik.swagger.jaxrs.listing.ResourceListingProvider;
+import com.wordnik.swagger.jaxrs.reader.DefaultJaxrsApiReader;
+import com.wordnik.swagger.reader.ClassReaders;
 
 /**
  * @author Federico Recio
@@ -43,7 +45,12 @@ public class SwaggerDropwizard<T extends Configuration> implements ConfiguredBun
     }
 
     public void onInitialize(Bootstrap<?> bootstrap) {
-        bootstrap.addBundle(new ViewBundle());
+        bootstrap.addBundle(new ViewBundle<Configuration>() {
+            @Override
+            public ImmutableMap<String, ImmutableMap<String, String>> getViewConfiguration(final Configuration configuration) {
+                return ImmutableMap.of();
+            }
+        });
     }
 
     @Override

--- a/src/test/java/io/federecio/dropwizard/swagger/TestApplicationWithPathSetProgramatically.java
+++ b/src/test/java/io/federecio/dropwizard/swagger/TestApplicationWithPathSetProgramatically.java
@@ -16,6 +16,7 @@
 package io.federecio.dropwizard.swagger;
 
 import io.dropwizard.Application;
+import io.dropwizard.server.DefaultServerFactory;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 
@@ -33,7 +34,8 @@ public class TestApplicationWithPathSetProgramatically extends Application<TestC
     }
 
     @Override
-    public void run(TestConfiguration configuration, Environment environment) throws Exception {
+    public void run(TestConfiguration configuration, final Environment environment) throws Exception {
+        ((DefaultServerFactory) configuration.getServerFactory()).setJerseyRootPath("/api/*");
         environment.jersey().setUrlPattern(BASE_PATH + "/*");
         environment.jersey().register(new TestResource());
         swaggerDropwizard.onRun(configuration, environment, "localhost");


### PR DESCRIPTION
First of all, thanks for the work with dropwizard-swagger, we appreciate it. We're already happy users of this DW bundle. But with Dropwizard 0.8.0 released, we rapidly migrated one of our in development applications to this brand new version. Some of other bundles used in this app didn't stopped to work, unfortunately dropwizard-swagger wasn't one of them.

The PR switches dropwizard-swagger to use Dropwizard 0.8.0. Although just few little changes were enough to everything work, I struggled to fix the programmatically path. I suspect that the reasons is that the `setUrlPattern` no longer works, and after some research the only solution I have found was this workaround https://github.com/dropwizard/dropwizard/issues/733. I tried other options without any success.

As I said, we already migrated one of our apps to DW8 and we are using this customized dropwizard-swagger in this app without any other issue. I'll appreciate your review in this PR.

There'll be another PR in `dropwizard-junit`, but there only one change in `pom.xml` file to use the Dropwizard 0.8.0.