### PR TITLE
Access to Swagger and Modify Swagger UI API Key

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 dropwizard-swagger
 ==================
 
-a Dropwizard bundle that serves Swagger UI static content and loads Swagger endpoints. Swagger UI static content is taken from https://github.com/wordnik/swagger-ui
+a Dropwizard bundle that serves Swagger UI static content and loads Swagger endpoints. Swagger UI static content is taken from https://github.com/swagger-api/swagger-ui
 
-Current version has been tested with Dropwizard 0.8.0 and Swagger 1.5.1-M2 which supports Swagger 2 spec!
+Current version has been tested with Dropwizard 0.8.0 and Swagger 1.5.4 which supports Swagger 2 spec!
 
 Note: if you come from previous versions there have been some changes in the way the bundle is configured, see details below.
 
@@ -21,6 +21,7 @@ dropwizard-swagger|Dropwizard|Swagger API|Swagger UI
        0.5.x      |   0.7.x  |   1.3.12  | v2.1.4-M1
        0.6.x      |   0.8.0  |   1.3.12  | v2.1.4-M1
        0.7.x      |   0.8.0  |   1.5.1-M2| v2.1.4-M1
+       0.8.x      |   0.8.4  |   1.5.4   | v2.1.4-M1
        
 How to use it
 -------------

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>io.federecio</groupId>
     <artifactId>dropwizard-swagger</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.8.1-wikia</version>
 
     <name>Dropwizard Swagger support</name>
     <description>A simple way to document your REST APIs in DropWizard using Swagger</description>
@@ -52,7 +52,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <file.encoding>UTF-8</file.encoding>
         <jdk.version>1.7</jdk.version>
-        <swagger.version>1.5.4</swagger.version>
+        <swagger.version>1.5.3</swagger.version>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     </scm>
 
     <properties>
-        <dropwizard.version>0.8.4</dropwizard.version>
+        <dropwizard.version>0.8.1</dropwizard.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <file.encoding>UTF-8</file.encoding>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>io.federecio</groupId>
     <artifactId>dropwizard-swagger</artifactId>
-    <version>0.7.1-SNAPSHOT</version>
+    <version>0.8.0-SNAPSHOT</version>
 
     <name>Dropwizard Swagger support</name>
     <description>A simple way to document your REST APIs in DropWizard using Swagger</description>
@@ -47,12 +47,12 @@
     </scm>
 
     <properties>
-        <dropwizard.version>0.8.0</dropwizard.version>
+        <dropwizard.version>0.8.4</dropwizard.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <file.encoding>UTF-8</file.encoding>
         <jdk.version>1.7</jdk.version>
-        <swagger.version>1.5.1-M2</swagger.version>
+        <swagger.version>1.5.4</swagger.version>
     </properties>
 
     <dependencies>
@@ -77,7 +77,7 @@
             <version>${dropwizard.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.wordnik</groupId>
+            <groupId>io.swagger</groupId>
             <artifactId>swagger-jersey2-jaxrs</artifactId>
             <version>${swagger.version}</version>
             <exclusions>
@@ -127,12 +127,16 @@
                 </exclusion>
 
                 <exclusion>
-                    <groupId>org.glassfish.jersey.media</groupId>
-                    <artifactId>jersey-media-multipart</artifactId>
+                    <groupId>org.glassfish.jersey.core</groupId>
+                    <artifactId>jersey-server</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>org.glassfish.jersey.containers</groupId>
                     <artifactId>jersey-container-servlet-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.glassfish.hk2.external</groupId>
+                    <artifactId>javax.inject</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -178,6 +182,12 @@
             <artifactId>dropwizard-junit</artifactId>
             <version>0.6</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.dropwizard</groupId>
+                    <artifactId>dropwizard-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.seleniumhq.selenium.client-drivers</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>io.federecio</groupId>
     <artifactId>dropwizard-swagger</artifactId>
-    <version>0.8.1-wikia</version>
+    <version>0.8.2-wikia</version>
 
     <name>Dropwizard Swagger support</name>
     <description>A simple way to document your REST APIs in DropWizard using Swagger</description>

--- a/src/main/java/io/federecio/dropwizard/swagger/SwaggerBundle.java
+++ b/src/main/java/io/federecio/dropwizard/swagger/SwaggerBundle.java
@@ -57,7 +57,10 @@ public abstract class SwaggerBundle<T extends Configuration> implements Configur
         ConfigurationHelper configurationHelper = new ConfigurationHelper(configuration, swaggerBundleConfiguration);
         new AssetsBundle(Constants.SWAGGER_RESOURCES_PATH, configurationHelper.getSwaggerUriPath(), null, Constants.SWAGGER_ASSETS_NAME).run(environment);
 
-        environment.jersey().register(new SwaggerResource(configurationHelper.getUrlPattern()));
+        environment.jersey().register(
+            new SwaggerResource(
+                configurationHelper.getUrlPattern(),
+                swaggerBundleConfiguration.getUiConfiguration()));
         environment.getObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL);
 
         BeanConfig beanConfig = setUpSwagger(swaggerBundleConfiguration,

--- a/src/main/java/io/federecio/dropwizard/swagger/SwaggerBundle.java
+++ b/src/main/java/io/federecio/dropwizard/swagger/SwaggerBundle.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.google.common.collect.ImmutableMap;
 import com.wordnik.swagger.jaxrs.config.BeanConfig;
 import com.wordnik.swagger.jaxrs.listing.ApiListingResource;
+import com.wordnik.swagger.models.Swagger;
 import io.dropwizard.Configuration;
 import io.dropwizard.ConfiguredBundle;
 import io.dropwizard.assets.AssetsBundle;
@@ -59,14 +60,22 @@ public abstract class SwaggerBundle<T extends Configuration> implements Configur
         environment.jersey().register(new SwaggerResource(configurationHelper.getUrlPattern()));
         environment.getObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL);
 
-        setUpSwagger(swaggerBundleConfiguration, configurationHelper.getUrlPattern());
+        BeanConfig beanConfig = setUpSwagger(swaggerBundleConfiguration,
+                                             configurationHelper.getUrlPattern());
+        setUpSwagger(beanConfig.getSwagger());
+
         environment.jersey().register(new ApiListingResource());
+        environment.getApplicationContext().setAttribute("swagger", beanConfig.getSwagger());
     }
 
     @SuppressWarnings("unused")
     protected abstract SwaggerBundleConfiguration getSwaggerBundleConfiguration(T configuration);
 
-    private void setUpSwagger(SwaggerBundleConfiguration swaggerBundleConfiguration, String urlPattern) {
+    @SuppressWarnings("unused")
+    protected void setUpSwagger(Swagger swagger) {}
+
+    private BeanConfig setUpSwagger(SwaggerBundleConfiguration swaggerBundleConfiguration,
+                                    String urlPattern) {
         BeanConfig config = new BeanConfig();
 
         if (swaggerBundleConfiguration.getTitle() != null) {
@@ -107,5 +116,7 @@ public abstract class SwaggerBundle<T extends Configuration> implements Configur
 
 
         config.setScan(true);
+
+        return config;
     }
 }

--- a/src/main/java/io/federecio/dropwizard/swagger/SwaggerBundle.java
+++ b/src/main/java/io/federecio/dropwizard/swagger/SwaggerBundle.java
@@ -62,10 +62,9 @@ public abstract class SwaggerBundle<T extends Configuration> implements Configur
 
         BeanConfig beanConfig = setUpSwagger(swaggerBundleConfiguration,
                                              configurationHelper.getUrlPattern());
-        setUpSwagger(beanConfig.getSwagger());
 
-        environment.jersey().register(new ApiListingResource());
         environment.getApplicationContext().setAttribute("swagger", beanConfig.getSwagger());
+        environment.jersey().register(new ApiListingResource());
     }
 
     @SuppressWarnings("unused")
@@ -116,6 +115,7 @@ public abstract class SwaggerBundle<T extends Configuration> implements Configur
 
 
         config.setScan(true);
+        setUpSwagger(config.getSwagger());
 
         return config;
     }

--- a/src/main/java/io/federecio/dropwizard/swagger/SwaggerBundle.java
+++ b/src/main/java/io/federecio/dropwizard/swagger/SwaggerBundle.java
@@ -16,15 +16,14 @@
 package io.federecio.dropwizard.swagger;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.google.common.collect.ImmutableMap;
-import com.wordnik.swagger.jaxrs.config.BeanConfig;
-import com.wordnik.swagger.jaxrs.listing.ApiListingResource;
 import io.dropwizard.Configuration;
 import io.dropwizard.ConfiguredBundle;
 import io.dropwizard.assets.AssetsBundle;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import io.dropwizard.views.ViewBundle;
+import io.swagger.jaxrs.config.BeanConfig;
+import io.swagger.jaxrs.listing.ApiListingResource;
 
 /**
  * A {@link io.dropwizard.ConfiguredBundle} that provides hassle-free configuration of Swagger and Swagger UI
@@ -38,12 +37,7 @@ public abstract class SwaggerBundle<T extends Configuration> implements Configur
 
     @Override
     public void initialize(Bootstrap<?> bootstrap) {
-        bootstrap.addBundle(new ViewBundle<Configuration>() {
-            @Override
-            public ImmutableMap<String, ImmutableMap<String, String>> getViewConfiguration(final Configuration configuration) {
-                return ImmutableMap.of();
-            }
-        });
+        bootstrap.addBundle(new ViewBundle<>());
     }
 
     @Override

--- a/src/main/java/io/federecio/dropwizard/swagger/SwaggerBundleConfiguration.java
+++ b/src/main/java/io/federecio/dropwizard/swagger/SwaggerBundleConfiguration.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
- * For the meaning of all these properties please refer to Swagger documentation or {@link com.wordnik.swagger.jaxrs.config.BeanConfig}
+ * For the meaning of all these properties please refer to Swagger documentation or {@link io.swagger.jaxrs.config.BeanConfig}
  *
  * @author Tristan Burch
  * @author Federico Recio
@@ -30,7 +30,7 @@ public class SwaggerBundleConfiguration {
     /**
      * This is the only property that is required for Swagger to work correctly.
      * <p/>
-     * It is a comma separated list of the all the packages that contain the {@link com.wordnik.swagger.annotations.Api}
+     * It is a comma separated list of the all the packages that contain the {@link io.swagger.annotations.Api}
      * annoted resources
      */
     @JsonProperty

--- a/src/main/java/io/federecio/dropwizard/swagger/SwaggerBundleConfiguration.java
+++ b/src/main/java/io/federecio/dropwizard/swagger/SwaggerBundleConfiguration.java
@@ -69,6 +69,9 @@ public class SwaggerBundleConfiguration {
     @JsonProperty
     private String uriPrefix;
 
+    @JsonProperty("ui")
+    private SwaggerUIConfiguration uiConfiguration = new SwaggerUIConfiguration();
+
     public String getResourcePackage() {
         return resourcePackage;
     }
@@ -139,6 +142,16 @@ public class SwaggerBundleConfiguration {
 
     public void setUriPrefix(String uriPrefix) {
         this.uriPrefix = uriPrefix;
+    }
+
+    @JsonProperty("ui")
+    public SwaggerUIConfiguration getUiConfiguration() {
+        return uiConfiguration;
+    }
+
+    @JsonProperty("ui")
+    public void setUiConfiguration(SwaggerUIConfiguration ui) {
+        this.uiConfiguration = ui;
     }
 
     @Override

--- a/src/main/java/io/federecio/dropwizard/swagger/SwaggerResource.java
+++ b/src/main/java/io/federecio/dropwizard/swagger/SwaggerResource.java
@@ -27,13 +27,15 @@ import javax.ws.rs.core.MediaType;
 @Produces(MediaType.TEXT_HTML)
 public class SwaggerResource {
     private final String urlPattern;
+    private final SwaggerUIConfiguration config;
 
-    public SwaggerResource(String urlPattern) {
+    public SwaggerResource(String urlPattern, SwaggerUIConfiguration config) {
         this.urlPattern = urlPattern;
+        this.config = config;
     }
 
     @GET
     public SwaggerView get() {
-        return new SwaggerView(urlPattern);
+        return new SwaggerView(urlPattern, config);
     }
 }

--- a/src/main/java/io/federecio/dropwizard/swagger/SwaggerUIConfiguration.java
+++ b/src/main/java/io/federecio/dropwizard/swagger/SwaggerUIConfiguration.java
@@ -1,0 +1,38 @@
+package io.federecio.dropwizard.swagger;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class SwaggerUIConfiguration {
+    @JsonProperty
+    String authName = "api_key";
+
+    @JsonProperty
+    String authKey = "api_key";
+
+    @JsonProperty
+    String authKeyLocation = "query";
+
+    public String getAuthName() {
+      return authName;
+    }
+
+    public void setAuthName(String authName) {
+      this.authName = authName;
+    }
+
+    public String getAuthKey() {
+      return authKey;
+    }
+
+    public void setAuthKey(String authKey) {
+      this.authKey = authKey;
+    }
+
+    public String getAuthKeyLocation() {
+      return authKeyLocation;
+    }
+
+    public void setAuthKeyLocation(String authKeyLocation) {
+      this.authKeyLocation = authKeyLocation;
+    }
+}

--- a/src/main/java/io/federecio/dropwizard/swagger/SwaggerView.java
+++ b/src/main/java/io/federecio/dropwizard/swagger/SwaggerView.java
@@ -29,9 +29,11 @@ public class SwaggerView extends View {
 
     private final String swaggerAssetsPath;
     private final String contextPath;
+    private final SwaggerUIConfiguration config;
 
-    protected SwaggerView(String urlPattern) {
+    protected SwaggerView(String urlPattern, SwaggerUIConfiguration config) {
         super("index.ftl", Charsets.UTF_8);
+        this.config = config;
 
         if (urlPattern.equals("/")) {
             swaggerAssetsPath = Constants.SWAGGER_URI_PATH;
@@ -60,5 +62,20 @@ public class SwaggerView extends View {
     @SuppressWarnings("unused")
     public String getContextPath() {
         return contextPath;
+    }
+
+    @SuppressWarnings("unused")
+    public String getAuthName() {
+        return config.getAuthName();
+    }
+
+    @SuppressWarnings("unused")
+    public String getAuthKey() {
+        return config.getAuthKey();
+    }
+
+    @SuppressWarnings("unused")
+    public String getAuthKeyLocation() {
+        return config.getAuthKeyLocation();
     }
 }

--- a/src/main/resources/io/federecio/dropwizard/swagger/index.ftl
+++ b/src/main/resources/io/federecio/dropwizard/swagger/index.ftl
@@ -55,7 +55,7 @@
         log("key: " + key);
         if(key && key.trim() != "") {
             log("added key " + key);
-            window.authorizations.add("api_key", new ApiKeyAuthorization("api_key", key, "query"));
+            window.authorizations.add("${authName}", new ApiKeyAuthorization("${authKey}", key, "${authKeyLocation}"));
         }
       }
 

--- a/src/test/java/io/federecio/dropwizard/swagger/DropwizardTest.java
+++ b/src/test/java/io/federecio/dropwizard/swagger/DropwizardTest.java
@@ -18,14 +18,11 @@ package io.federecio.dropwizard.swagger;
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.jayway.restassured.RestAssured;
-import com.wordnik.swagger.jaxrs.listing.ApiListingResource;
 import org.eclipse.jetty.http.HttpStatus;
 import org.hamcrest.core.StringContains;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -45,13 +42,6 @@ public abstract class DropwizardTest {
     @Before
     public void setPort() {
         RestAssured.port = port;
-    }
-
-    @BeforeClass
-    public static void crap() throws Exception {
-        Field initialized = ApiListingResource.class.getDeclaredField("initialized");
-        initialized.setAccessible(true);
-        initialized.set(null, false);
     }
 
     @Test

--- a/src/test/java/io/federecio/dropwizard/swagger/TestResource.java
+++ b/src/test/java/io/federecio/dropwizard/swagger/TestResource.java
@@ -15,8 +15,8 @@
  */
 package io.federecio.dropwizard.swagger;
 
-import com.wordnik.swagger.annotations.Api;
-import com.wordnik.swagger.annotations.ApiOperation;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;


### PR DESCRIPTION
There currently isn't a way to access the `Swagger` object and add any additional documentation your application might need, like `securityDefinition` or tags (see #55). This PR introduces a new function to `SwaggerBundle`:

``` java
protected void setUpSwagger(Swagger swagger)
```

Which allows us to provide these properties, and then sets the application context's `swagger` attribute to this modified `Swagger` object, so it can be properly fetched in `ApiListingResource`.

Also introducing a `SwaggerUIConfiguration` class to configure some parts of the Swagger UI on `/swagger`. For now, the only controllable parts are the API key's name, it's location (`header` or `query`) and the name for the header or query param. This is configured like so:

``` yaml
# other configs
swaggerConfiguration:
  ui:
    authName: "api_key"
    authKey: "x-some-header"
    authKeyLocation: "header"
```

And default to `api_key`, `api_key`, `query`, which is their current value in the Swagger UI.
