### PR TITLE
Upgrade to Dropwizard 0.8.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ dropwizard-swagger
 
 a Dropwizard bundle that serves Swagger UI static content and loads Swagger endpoints. Swagger UI static content is taken from https://github.com/wordnik/swagger-ui
 
-Current version has been tested with Dropwizard 0.8.0 and Swagger 1.5.1-M2 which supports Swagger 2 spec!
+Current version has been tested with Dropwizard 0.8.3 and Swagger 1.5.1-M2 which supports Swagger 2 spec!
 
 Note: if you come from previous versions there have been some changes in the way the bundle is configured, see details below.
 
@@ -20,7 +20,7 @@ dropwizard-swagger|Dropwizard|Swagger API|Swagger UI
      < 0.5        |   0.7.x  |   1.3.2   |    ?
        0.5.x      |   0.7.x  |   1.3.12  | v2.1.4-M1
        0.6.x      |   0.8.0  |   1.3.12  | v2.1.4-M1
-       0.7.x      |   0.8.0  |   1.5.1-M2| v2.1.4-M1
+       0.7.x      |   0.8.x  |   1.5.1-M2| v2.1.4-M1
        
 How to use it
 -------------

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     </scm>
 
     <properties>
-        <dropwizard.version>0.8.2</dropwizard.version>
+        <dropwizard.version>0.8.3</dropwizard.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <file.encoding>UTF-8</file.encoding>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     </scm>
 
     <properties>
-        <dropwizard.version>0.8.3</dropwizard.version>
+        <dropwizard.version>0.8.4</dropwizard.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <file.encoding>UTF-8</file.encoding>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     </scm>
 
     <properties>
-        <dropwizard.version>0.8.0</dropwizard.version>
+        <dropwizard.version>0.8.2</dropwizard.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <file.encoding>UTF-8</file.encoding>
@@ -55,11 +55,20 @@
         <swagger.version>1.5.1-M2</swagger.version>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.dropwizard</groupId>
+                <artifactId>dropwizard-core</artifactId>
+                <version>${dropwizard.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-core</artifactId>
-            <version>${dropwizard.version}</version>
         </dependency>
         <dependency>
             <groupId>io.dropwizard</groupId>

--- a/src/main/java/io/federecio/dropwizard/swagger/SwaggerBundle.java
+++ b/src/main/java/io/federecio/dropwizard/swagger/SwaggerBundle.java
@@ -15,6 +15,7 @@
  */
 package io.federecio.dropwizard.swagger;
 
+import java.util.Map;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.google.common.collect.ImmutableMap;
 import com.wordnik.swagger.jaxrs.config.BeanConfig;
@@ -40,7 +41,7 @@ public abstract class SwaggerBundle<T extends Configuration> implements Configur
     public void initialize(Bootstrap<?> bootstrap) {
         bootstrap.addBundle(new ViewBundle<Configuration>() {
             @Override
-            public ImmutableMap<String, ImmutableMap<String, String>> getViewConfiguration(final Configuration configuration) {
+            public Map<String, Map<String, String>> getViewConfiguration(final Configuration configuration) {
                 return ImmutableMap.of();
             }
         });


### PR DESCRIPTION
The `<dependencyManagement>` portion was added to work around the `dropwizard-core` dependency in `dropwizard-junit`.
