### PR TITLE
Io.swagger upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <file.encoding>UTF-8</file.encoding>
         <jdk.version>1.7</jdk.version>
-        <swagger.version>1.5.1-M2</swagger.version>
+        <swagger.version>1.5.0</swagger.version>
     </properties>
 
     <dependencies>
@@ -77,7 +77,7 @@
             <version>${dropwizard.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.wordnik</groupId>
+            <groupId>io.swagger</groupId>
             <artifactId>swagger-jersey2-jaxrs</artifactId>
             <version>${swagger.version}</version>
             <exclusions>
@@ -125,7 +125,6 @@
                     <groupId>com.fasterxml.jackson.core</groupId>
                     <artifactId>jackson-databind</artifactId>
                 </exclusion>
-
                 <exclusion>
                     <groupId>org.glassfish.jersey.media</groupId>
                     <artifactId>jersey-media-multipart</artifactId>
@@ -135,6 +134,12 @@
                     <artifactId>jersey-container-servlet-core</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.media</groupId>
+            <artifactId>jersey-media-multipart</artifactId>
+            <version>2.16</version>
+            <scope>runtime</scope>
         </dependency>
 
         <!-- xml-apis should be on version 1.4.01 for selenium to work -->

--- a/src/main/java/io/federecio/dropwizard/swagger/SwaggerBundle.java
+++ b/src/main/java/io/federecio/dropwizard/swagger/SwaggerBundle.java
@@ -17,14 +17,15 @@ package io.federecio.dropwizard.swagger;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.google.common.collect.ImmutableMap;
-import com.wordnik.swagger.jaxrs.config.BeanConfig;
-import com.wordnik.swagger.jaxrs.listing.ApiListingResource;
+
 import io.dropwizard.Configuration;
 import io.dropwizard.ConfiguredBundle;
 import io.dropwizard.assets.AssetsBundle;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import io.dropwizard.views.ViewBundle;
+import io.swagger.jaxrs.config.BeanConfig;
+import io.swagger.jaxrs.listing.ApiListingResource;
 
 /**
  * A {@link io.dropwizard.ConfiguredBundle} that provides hassle-free configuration of Swagger and Swagger UI

--- a/src/test/java/io/federecio/dropwizard/swagger/DropwizardTest.java
+++ b/src/test/java/io/federecio/dropwizard/swagger/DropwizardTest.java
@@ -18,12 +18,14 @@ package io.federecio.dropwizard.swagger;
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.jayway.restassured.RestAssured;
-import com.wordnik.swagger.jaxrs.listing.ApiListingResource;
+
 import org.eclipse.jetty.http.HttpStatus;
 import org.hamcrest.core.StringContains;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
+import io.swagger.jaxrs.listing.ApiListingResource;
 
 import java.lang.reflect.Field;
 import java.util.ArrayList;

--- a/src/test/java/io/federecio/dropwizard/swagger/TestResource.java
+++ b/src/test/java/io/federecio/dropwizard/swagger/TestResource.java
@@ -15,11 +15,14 @@
  */
 package io.federecio.dropwizard.swagger;
 
-import com.wordnik.swagger.annotations.Api;
-import com.wordnik.swagger.annotations.ApiOperation;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+
+import com.google.common.base.Optional;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
 
 /**
@@ -32,7 +35,7 @@ public class TestResource {
 
     @GET
     @ApiOperation(OPERATION_DESCRIPTION)
-    public Response dummyEndpoint() {
+    public Response dummyEndpoint(@QueryParam("dummy") final Optional<String> dummy) {
         return Response.ok().build();
     }
 }


### PR DESCRIPTION
Having run into an issue https://github.com/federecio/dropwizard-swagger/issues/65 an `IllegalArgumentException` is thrown when an `Optional` argument is in an annotated method signature . I found by upgrading to the latest Swagger2 api v1.5.0 the issue apparently vanishes.

This PR also covers the request for the v1.5.0 upgrade https://github.com/federecio/dropwizard-swagger/issues/58 but seems to supersedes plans for a more thorough Swagger2 integration https://github.com/federecio/dropwizard-swagger/issues/22. Given that this is a response to a BUG in the previous version of swagger the PR should be considered on those grounds.

I did find that the new version of the API introduces an annoying runtime dependency, `org.glassfish.jersey.media.multipart.FormDataParam` ,which had to be declared in the build independently.

```
<dependency>
            <groupId>org.glassfish.jersey.media</groupId>
            <artifactId>jersey-media-multipart</artifactId>
            <version>2.16</version>
            <scope>runtime</scope>
</dependency>
```
