### PR TITLE
Add info about Firefox needed to run the tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,3 +98,7 @@ Contributors
 * Flemming Frandsen https://github.com/dren-dk
 * Tristan Burch [tburch] (https://github.com/tburch)
 * Matt Carrier [mattcarrier] (https://github.com/mattcarrier)
+
+Development
+------------
+Firefox needs to be installed for the selenium tests to run.


### PR DESCRIPTION
I was a little surprised by this - just adding it in case it helps.
