### PR TITLE
Updating for dropwizard 1.0.0 and dropwizard-junit 0.7 version bump

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>io.federecio</groupId>
     <artifactId>dropwizard-swagger</artifactId>
-    <version>0.7.1-SNAPSHOT</version>
+    <version>0.8.0-SNAPSHOT</version>
 
     <name>Dropwizard Swagger support</name>
     <description>A simple way to document your REST APIs in DropWizard using Swagger</description>
@@ -47,11 +47,11 @@
     </scm>
 
     <properties>
-        <dropwizard.version>0.8.0</dropwizard.version>
+        <dropwizard.version>1.0.0</dropwizard.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <file.encoding>UTF-8</file.encoding>
-        <jdk.version>1.7</jdk.version>
+        <jdk.version>1.8</jdk.version>
         <swagger.version>1.5.1-M2</swagger.version>
     </properties>
 
@@ -176,7 +176,7 @@
         <dependency>
             <groupId>io.federecio</groupId>
             <artifactId>dropwizard-junit</artifactId>
-            <version>0.6</version>
+            <version>0.7</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -273,24 +273,6 @@
                         <goals>
                             <goal>integration-test</goal>
                             <goal>verify</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <version>1.3.1</version>
-                <executions>
-                    <execution>
-                        <id>enforce</id>
-                        <configuration>
-                            <rules>
-                                <DependencyConvergence />
-                            </rules>
-                        </configuration>
-                        <goals>
-                            <goal>enforce</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/src/main/java/io/federecio/dropwizard/swagger/ConfigurationHelper.java
+++ b/src/main/java/io/federecio/dropwizard/swagger/ConfigurationHelper.java
@@ -20,6 +20,8 @@ import io.dropwizard.server.DefaultServerFactory;
 import io.dropwizard.server.ServerFactory;
 import io.dropwizard.server.SimpleServerFactory;
 
+import java.util.Optional;
+
 /**
  * Wrapper around Dropwizard's configuration and the bundle's config that simplifies getting some
  * information from them.
@@ -43,7 +45,7 @@ public class ConfigurationHelper {
             return swaggerBundleConfiguration.getUriPrefix();
         }
 
-        String rootPath;
+        Optional<String> rootPath;
 
         ServerFactory serverFactory = configuration.getServerFactory();
 
@@ -53,7 +55,9 @@ public class ConfigurationHelper {
             rootPath = ((DefaultServerFactory) serverFactory).getJerseyRootPath();
         }
 
-        return stripUrlSlashes(rootPath);
+        String rootPathOrNull = rootPath.orElse(null);
+
+        return stripUrlSlashes(rootPathOrNull);
     }
 
     public String getUrlPattern() {

--- a/src/main/java/io/federecio/dropwizard/swagger/SwaggerBundle.java
+++ b/src/main/java/io/federecio/dropwizard/swagger/SwaggerBundle.java
@@ -16,15 +16,18 @@
 package io.federecio.dropwizard.swagger;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.google.common.collect.ImmutableMap;
 import com.wordnik.swagger.jaxrs.config.BeanConfig;
 import com.wordnik.swagger.jaxrs.listing.ApiListingResource;
+
 import io.dropwizard.Configuration;
 import io.dropwizard.ConfiguredBundle;
 import io.dropwizard.assets.AssetsBundle;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import io.dropwizard.views.ViewBundle;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * A {@link io.dropwizard.ConfiguredBundle} that provides hassle-free configuration of Swagger and Swagger UI
@@ -40,8 +43,8 @@ public abstract class SwaggerBundle<T extends Configuration> implements Configur
     public void initialize(Bootstrap<?> bootstrap) {
         bootstrap.addBundle(new ViewBundle<Configuration>() {
             @Override
-            public ImmutableMap<String, ImmutableMap<String, String>> getViewConfiguration(final Configuration configuration) {
-                return ImmutableMap.of();
+            public Map<String, Map<String, String>> getViewConfiguration(final Configuration configuration) {
+                return new HashMap<>();
             }
         });
     }


### PR DESCRIPTION
## Summary of changes
1. Version bumps for Dropwizard 1.0.0:
   - Java version updated to 1.8
   - Dropwizard version bumped to 1.0.0
   - Dropwizard-JUnit version bumped to 0.7 (see upstream pull request https://github.com/federecio/dropwizard-junit/pull/9 )
2. Minor code changes to handle changed Dropwizard APIs
   - `getViewConfiguration` in `SwaggerBundle.java` changed from returning `ImmutableMap` to vanilla `Map`
   - `getJerseyRootPath` in `ConfigurationHelper.java` changed to handle `Optional<String>` returned from config properties
3. Maven Enforcer plugin DependencyConvergence check removed due to unresolved upstream conflicts (full detail on conflicting dependencies listed below)

Conflicting dependencies in DependencyConvergence check:

> [WARNING]
> Dependency convergence error for org.apache.commons:commons-lang3:3.4 paths to dependency are:
> +-io.federecio:dropwizard-swagger:0.8.0-SNAPSHOT
>   +-io.dropwizard:dropwizard-core:1.0.0
>     +-io.dropwizard:dropwizard-configuration:1.0.0
>       +-org.apache.commons:commons-lang3:3.4
> and
> +-io.federecio:dropwizard-swagger:0.8.0-SNAPSHOT
>   +-io.dropwizard:dropwizard-core:1.0.0
>     +-io.dropwizard:dropwizard-jersey:1.0.0
>       +-org.apache.commons:commons-lang3:3.4
> and
> +-io.federecio:dropwizard-swagger:0.8.0-SNAPSHOT
>   +-org.seleniumhq.selenium:selenium-java:2.45.0
>     +-org.seleniumhq.selenium:selenium-htmlunit-driver:2.45.0
>       +-net.sourceforge.htmlunit:htmlunit:2.15
>         +-org.apache.commons:commons-lang3:3.3.2
> 
> [WARNING]
> Dependency convergence error for org.slf4j:slf4j-api:1.7.21 paths to dependency are:
> +-io.federecio:dropwizard-swagger:0.8.0-SNAPSHOT
>   +-io.dropwizard:dropwizard-core:1.0.0
>     +-io.dropwizard:dropwizard-jackson:1.0.0
>       +-org.slf4j:slf4j-api:1.7.21
> and
> +-io.federecio:dropwizard-swagger:0.8.0-SNAPSHOT
>   +-io.dropwizard:dropwizard-core:1.0.0
>     +-io.dropwizard:dropwizard-logging:1.0.0
>       +-org.slf4j:slf4j-api:1.7.21
> and
> +-io.federecio:dropwizard-swagger:0.8.0-SNAPSHOT
>   +-io.dropwizard:dropwizard-core:1.0.0
>     +-io.dropwizard:dropwizard-logging:1.0.0
>       +-org.slf4j:jul-to-slf4j:1.7.21
>         +-org.slf4j:slf4j-api:1.7.21
> and
> +-io.federecio:dropwizard-swagger:0.8.0-SNAPSHOT
>   +-io.dropwizard:dropwizard-core:1.0.0
>     +-io.dropwizard:dropwizard-logging:1.0.0
>       +-org.slf4j:log4j-over-slf4j:1.7.21
>         +-org.slf4j:slf4j-api:1.7.21
> and
> +-io.federecio:dropwizard-swagger:0.8.0-SNAPSHOT
>   +-io.dropwizard:dropwizard-core:1.0.0
>     +-io.dropwizard:dropwizard-logging:1.0.0
>       +-org.slf4j:jcl-over-slf4j:1.7.21
>         +-org.slf4j:slf4j-api:1.7.21
> and
> +-io.federecio:dropwizard-swagger:0.8.0-SNAPSHOT
>   +-io.dropwizard:dropwizard-core:1.0.0
>     +-io.dropwizard:dropwizard-metrics:1.0.0
>       +-org.slf4j:slf4j-api:1.7.21
> and
> +-io.federecio:dropwizard-swagger:0.8.0-SNAPSHOT
>   +-io.dropwizard:dropwizard-core:1.0.0
>     +-io.dropwizard:dropwizard-servlets:1.0.0
>       +-org.slf4j:slf4j-api:1.7.21
> and
> +-io.federecio:dropwizard-swagger:0.8.0-SNAPSHOT
>   +-io.dropwizard:dropwizard-core:1.0.0
>     +-io.dropwizard:dropwizard-servlets:1.0.0
>       +-io.dropwizard.metrics:metrics-annotation:3.1.2
>         +-org.slf4j:slf4j-api:1.7.7
> and
> +-io.federecio:dropwizard-swagger:0.8.0-SNAPSHOT
>   +-io.dropwizard:dropwizard-core:1.0.0
>     +-io.dropwizard:dropwizard-lifecycle:1.0.0
>       +-org.slf4j:slf4j-api:1.7.21
> 
> [WARNING]
> Dependency convergence error for com.fasterxml.jackson.core:jackson-annotations:2.7.6 paths to dependency are:
> +-io.federecio:dropwizard-swagger:0.8.0-SNAPSHOT
>   +-io.dropwizard:dropwizard-core:1.0.0
>     +-io.dropwizard:dropwizard-util:1.0.0
>       +-com.fasterxml.jackson.core:jackson-annotations:2.7.6
> and
> +-io.federecio:dropwizard-swagger:0.8.0-SNAPSHOT
>   +-io.dropwizard:dropwizard-core:1.0.0
>     +-io.dropwizard:dropwizard-jackson:1.0.0
>       +-com.fasterxml.jackson.core:jackson-annotations:2.7.6
> and
> +-io.federecio:dropwizard-swagger:0.8.0-SNAPSHOT
>   +-io.dropwizard:dropwizard-core:1.0.0
>     +-io.dropwizard:dropwizard-jackson:1.0.0
>       +-com.fasterxml.jackson.core:jackson-databind:2.7.6
>         +-com.fasterxml.jackson.core:jackson-annotations:2.7.0
> and
> +-io.federecio:dropwizard-swagger:0.8.0-SNAPSHOT
>   +-io.dropwizard:dropwizard-core:1.0.0
>     +-io.dropwizard:dropwizard-jackson:1.0.0
>       +-com.fasterxml.jackson.datatype:jackson-datatype-joda:2.7.6
>         +-com.fasterxml.jackson.core:jackson-annotations:2.7.0
> and
> +-io.federecio:dropwizard-swagger:0.8.0-SNAPSHOT
>   +-io.dropwizard:dropwizard-core:1.0.0
>     +-io.dropwizard:dropwizard-jersey:1.0.0
>       +-com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:2.7.6
>         +-com.fasterxml.jackson.module:jackson-module-jaxb-annotations:2.7.6
>           +-com.fasterxml.jackson.core:jackson-annotations:2.7.0
