### PR TITLE
Modified to avoid changing the default behavior of ObjectMapper.

### DIFF
--- a/src/main/java/io/federecio/dropwizard/swagger/SwaggerBundle.java
+++ b/src/main/java/io/federecio/dropwizard/swagger/SwaggerBundle.java
@@ -57,7 +57,6 @@ public abstract class SwaggerBundle<T extends Configuration> implements Configur
         new AssetsBundle(Constants.SWAGGER_RESOURCES_PATH, configurationHelper.getSwaggerUriPath(), null, Constants.SWAGGER_ASSETS_NAME).run(environment);
 
         environment.jersey().register(new SwaggerResource(configurationHelper.getUrlPattern()));
-        environment.getObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL);
 
         setUpSwagger(swaggerBundleConfiguration, configurationHelper.getUrlPattern());
         environment.jersey().register(new ApiListingResource());


### PR DESCRIPTION
This once caused an incident in the production environment.